### PR TITLE
fix bATOM standalone + remove logging statements

### DIFF
--- a/src/bAtomPrice.js
+++ b/src/bAtomPrice.js
@@ -41,7 +41,6 @@ export async function bAtomPriceSafe() {
     bAtomPriceInfo(),
     ethBlockNumber(),
   ])
-  console.log(deviationBlockOffsets);
   const referenceValues = await Promise.all(
     deviationBlockOffsets
       .map(offset => currentBlockHex - offset)
@@ -57,7 +56,6 @@ export async function bAtomPriceSafe() {
     currentPriceInfo,
     referenceValues,
   )
-  console.log('bAtomPriceSafe:', currentPriceInfo.bAtomPrice);
   return currentPriceInfo.bAtomPrice.toFixed(8)
 }
 

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -25,14 +25,14 @@ setGlobals({
   env: ENV,
   sentryProjectId: SENTRY_PROJECT_ID,
   sentryKey: SENTRY_KEY,
-  ethRpcs: ETH_RPCS,
-  deviationBlockOffsets: DEVIATION_BLOCK_OFFSETS && DEVIATION_BLOCK_OFFSETS,
-  bAtomPriceLimits: BATOM_PRICE_LIMITS && BATOM_PRICE_LIMITS,
-  atomPriceLimits: ATOM_PRICE_LIMITS && ATOM_PRICE_LIMITS,
+  ethRpcs: JSON.parse(ETH_RPCS),
+  deviationBlockOffsets:
+    DEVIATION_BLOCK_OFFSETS && JSON.parse(DEVIATION_BLOCK_OFFSETS),
+  bAtomPriceLimits: BATOM_PRICE_LIMITS && JSON.parse(BATOM_PRICE_LIMITS),
+  atomPriceLimits: ATOM_PRICE_LIMITS && JSON.parse(ATOM_PRICE_LIMITS),
   requestTimeout: REQUEST_TIMEOUT && Number.parseInt(REQUEST_TIMEOUT, 10),
 })
 
 export const getBatomPriceSafeStandalone = () => {
-  console.log();
   return bAtomPriceSafe()
 }


### PR DESCRIPTION
This fixes an issue with the `bATOM` standalone file. We need to use `JSON.parse` when reading `JSON` env vars. This solution follows what was done in https://github.com/Anchor-Protocol/beth-price-feed/blob/main/src/standalone.js#L30.

s/o to [kjessec](https://github.com/kjessec) for the fix!